### PR TITLE
fix: class names

### DIFF
--- a/themes/AvatarDecorationCheckmark/scss/_vars.scss
+++ b/themes/AvatarDecorationCheckmark/scss/_vars.scss
@@ -5,11 +5,11 @@ $checkmark: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"
 $locations: (
     "profile": (
         "wrapper": ".userProfileInner_c69a7b",
-        "username": ":is(.nickname_c9ccf6, .container-3g15px, .text-lg\\/semibold_dc00ef)"
+        "username": ":is(.nickname_c9ccf6, .container_c9ccf6, .text-lg\\/semibold_dc00ef, .nickname_c32acf)"
     ),
     "message": (
-        "wrapper": ".contents_ec86aa",
-        "username": ".username_ec86aa:not(.vc-rdb-view .username_ec86aa)"
+        "wrapper": ".contents_f9f2ca",
+        "username": ".username_f9f2ca:not(.vc-rdb-view .username_f9f2ca)"
     ),
     "dm-header": (
         "wrapper": ".container_c2668b",

--- a/themes/ImageLink/scss/main.scss
+++ b/themes/ImageLink/scss/main.scss
@@ -1,10 +1,10 @@
 // Image actions
-.optionsContainer_aa8ea9 {
+.optionsContainer_fb6520 {
     inset: 0;
     margin-top: 0;
 
     // Link
-    @at-root .downloadLink_aa8ea9 {
+    @at-root .downloadLink_fb6520 {
         position: absolute;
         inset: 0;
         display: flex;

--- a/themes/ShowOriginalLink/scss/main.scss
+++ b/themes/ShowOriginalLink/scss/main.scss
@@ -1,4 +1,4 @@
-.messageContent_ec86aa a[href][title*="("] {
+.messageContent_f9f2ca a[href][title*="("] {
     position: relative;
     overflow: visible;
     border-radius: 4px;


### PR DESCRIPTION
- Fixed class names of `ShowOriginalLink`, `ImageLink` and `AvatarDecorationCheckmark`.
- Added the `AvatarDecorationCheckmark` to the nicknames on the new profiles.

Reporting two bugs I didn't fix, it would require some more work:
- `AvatarDecorationCheckmark` has a bug with new profiles where the checkmark is being applied on activities. This is due to how the checkmark is applied to DMs.
- `ProfileBannerHeight` has some wrong class names, I didn't update them because something would have to be redone with the new profiles regardless since it's position is moved in the wrong place. This snippet also has the customization settings are in scss in the readme, which the mod editors do not accept.
